### PR TITLE
Feature/allow multiple npm tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,25 @@ steps:
           registry: //myprivatenpm.com/
 ```
 
+If you have _multiple_ private repositories, you can specify them with the following:
+
+```yml
+steps:
+  - command: yarn install
+    plugins:
+      - seek-oss/private-npm#v1.2.0:
+          multi-registries:
+            - env: "MY_TOKEN_1"
+              path: //myprivatenpm.com/
+            - env: "MY_TOKEN_2"
+              path: //myotherprivatenpm.com/
+```
+
+Take note that in `multi-registries` mode, only `env` field can be used and the `path` field is required. The fields `token` and `file` will not work.
+
 ## Configuration
 
-> **NOTE** Even thought `env`, `file` and `token` are described as optional, _at least one must be set_ or the plugin 
+> **NOTE** Even though `env`, `file` and `token` are described as optional, _at least one must be set_ or the plugin 
 > will fail.
 
 ### `env` (optional)
@@ -98,6 +114,9 @@ Example: `//myprivatenpm.com/`
 The path to the .npmrc that will be created.  Please ensure you supply the trailing `/`!
 
 Example: `./project/path/`
+
+### `multi-registries` (optional)
+An array of objects, each containing `env` and `path` to support multiple private registries.
 
 ## License
 MIT (see [LICENSE](./LICENSE))

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -8,6 +8,40 @@ SEEK_OSS_PRIVATE_NPM_FILE=${BUILDKITE_PLUGIN_PRIVATE_NPM_FILE:-''}
 SEEK_OSS_PRIVATE_NPM_ENV=${BUILDKITE_PLUGIN_PRIVATE_NPM_ENV:-''}
 SEEK_OSS_PRIVATE_NPM_OUTPUT_PATH=${BUILDKITE_PLUGIN_PRIVATE_NPM_OUTPUT_PATH:-'./'}
 
+# Handle multi-registries scenario
+if [[ -n ${BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_ENV:-} && \
+      -n ${BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_PATH:-} ]]; then
+
+  # Validate that other fields are not provided
+  if [[ -n $SEEK_OSS_PRIVATE_NPM_TOKEN || \
+        -n $SEEK_OSS_PRIVATE_NPM_FILE || \
+        -n $SEEK_OSS_PRIVATE_NPM_ENV ]]; then
+    echo ':no_entry_sign: :npm: :package: Failed! When multi-registries are provided, the following fields cannot be set: env, file, token'
+    exit 1
+  fi
+
+  echo '--- Setting up access for :no_entry_sign: :npm: :package:'
+
+  OUTPUT_FILE="${SEEK_OSS_PRIVATE_NPM_OUTPUT_PATH}.npmrc"
+  mkdir -p "${OUTPUT_FILE%/*}" && touch $OUTPUT_FILE
+
+  reg_index=0
+  env_base_name=BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_${reg_index}_ENV
+  path_base_name=BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_${reg_index}_PATH
+
+  while [[ -n ${!env_base_name:-} && -n ${!path_base_name:-} ]]
+  do
+    temp_env=${!env_base_name}
+    echo "${!path_base_name}:_authToken=${!temp_env}" >> $OUTPUT_FILE
+    ((++reg_index))
+    env_base_name=BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_${reg_index}_ENV
+    path_base_name=BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_${reg_index}_PATH
+  done
+
+  echo "save-exact=true" >> $OUTPUT_FILE
+  exit 0
+fi
+
 if { [[ -n "${SEEK_OSS_PRIVATE_NPM_FILE}" ]] && [[ -n "${SEEK_OSS_PRIVATE_NPM_ENV}" ]]; } \
   || { [[ -n "${SEEK_OSS_PRIVATE_NPM_FILE}" ]] && [[ -n "${SEEK_OSS_PRIVATE_NPM_TOKEN}" ]]; } \
   || { [[ -n "${SEEK_OSS_PRIVATE_NPM_TOKEN}" ]] && [[ -n "${SEEK_OSS_PRIVATE_NPM_ENV}" ]]; }

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,7 +5,19 @@ public: true
 requirements:
   - bash
 configuration:
+  definitions:
+    multi-registry-object:
+      type: object
+      properties:
+        env:
+          type: string
+        path:
+          type: string
   properties:
+    multi-registries:
+      type: array
+      items:
+        $ref: '#/definitions/multi-registry-object'
     registry:
       type: string
     token:

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -136,7 +136,7 @@ teardown() {
 }
 
 # There is an exclusive relationship between file, env, and token.  These tests ensure only value is set and fail with 
-# a meaninful message otherwise
+# a meaningful message otherwise
 @test "fails if env and file are both set" {
   export BUILDKITE_PLUGIN_PRIVATE_NPM_FILE='my_token_file'
   export BUILDKITE_PLUGIN_PRIVATE_NPM_ENV='MY_ENV_VAR'

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -9,6 +9,15 @@ teardown() {
   unset BUILDKITE_PLUGIN_PRIVATE_NPM_FILE
   unset BUILDKITE_PLUGIN_PRIVATE_NPM_REGISTRY
   unset MY_ENV_VAR
+  unset MY_ENV_VAR1
+  unset MY_ENV_VAR2
+  unset MY_ENV_VAR3
+  unset BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_ENV
+  unset BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_PATH
+  unset BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_1_ENV
+  unset BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_1_PATH
+  unset BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_2_ENV
+  unset BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_2_PATH
   rm -fr my_token_file
   rm -fr my_empty_file
 }
@@ -128,6 +137,31 @@ teardown() {
   assert_equal "$(head -n1 ./tests/path/to/project/.npmrc)" '//registry.npmjs.org/:_authToken=abc123'
 }
 
+@test  "creates a npmrc file when multi-registries are supplied' {
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_OUTPUT_PATH='./tests/path/to/project/'
+
+  export MY_ENV_VAR1='abc123'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_ENV='MY_ENV_VAR1'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_PATH='//myprivateregistry1.org/'
+
+  export MY_ENV_VAR2='def123'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_1_ENV='MY_ENV_VAR2'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_1_PATH='//myprivateregistry2.org/'
+
+  export MY_ENV_VAR3='ghi123'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_2_ENV='MY_ENV_VAR3'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_2_PATH='//myprivateregistry3.org/'
+
+  run $PWD/hooks/pre-command
+  
+  assert_success
+  assert [ -e './tests/path/to/project/.npmrc' ]
+  assert_equal "$(head -n 1 ./tests/path/to/project/.npmrc)" '//myprivateregistry1.org/:_authToken=abc123'
+  assert_equal "$(head -n 2 ./tests/path/to/project/.npmrc | tail -n 1)" '//myprivateregistry2.org/:_authToken=def123'
+  assert_equal "$(head -n 3 ./tests/path/to/project/.npmrc | tail -n 1)" '//myprivateregistry3.org/:_authToken=ghi123'
+  assert_equal "$(head -n 4 ./tests/path/to/project/.npmrc | tail -n 1)" 'save-exact=true'
+}
+
 @test "the command fails if none of the fields are not set" {
   run $PWD/hooks/pre-command
 
@@ -135,7 +169,7 @@ teardown() {
   refute [ -e '.npmrc' ]
 }
 
-# There is an exclusive relationship between file, env, and token.  These tests ensure only value is set and fail with 
+# There is an exclusive relationship between file, env, token, and multi-registries. These tests ensure only value is set and fail with 
 # a meaningful message otherwise
 @test "fails if env and file are both set" {
   export BUILDKITE_PLUGIN_PRIVATE_NPM_FILE='my_token_file'
@@ -179,5 +213,41 @@ teardown() {
 
   assert_failure
   assert_output ':no_entry_sign: :npm: :package: Failed! Only one of file, env or token parameters may be set'
+  refute [ -e '.npmrc' ]
+}
+
+@test "fails if both multi-registries and env are set" {
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_ENV='MY_ENV_VAR'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_ENV='MY_ENV_VAR'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_PATH='/myprivateregistry.org//'
+
+  run $PWD/hooks/pre-command
+
+  assert_failure
+  assert_output ':no_entry_sign: :npm: :package: Failed! When multi-registries are provided, the following fields cannot be set: env, file, token'
+  refute [ -e '.npmrc' ]
+}
+
+@test "fails if both multi-registries and file are set" {
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_FILE='my_token_file'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_ENV='MY_ENV_VAR'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_PATH='/myprivateregistry.org//'
+
+  run $PWD/hooks/pre-command
+
+  assert_failure
+  assert_output ':no_entry_sign: :npm: :package: Failed! When multi-registries are provided, the following fields cannot be set: env, file, token'
+  refute [ -e '.npmrc' ]
+}
+
+@test "fails if both multi-registries and token are set" {
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_TOKEN='abc123'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_ENV='MY_ENV_VAR'
+  export BUILDKITE_PLUGIN_PRIVATE_NPM_MULTI_REGISTRIES_0_PATH='/myprivateregistry.org//'
+
+  run $PWD/hooks/pre-command
+
+  assert_failure
+  assert_output ':no_entry_sign: :npm: :package: Failed! When multi-registries are provided, the following fields cannot be set: env, file, token'
   refute [ -e '.npmrc' ]
 }


### PR DESCRIPTION
Addresses #6 

## What was Verified
New tests were written to test `multi-registries` feature and related validation. All tests passing.

Take note that the mapping of config values from buildkite pipeline.yml to bash script variables were **not verified**. Guidance needed on doing this.


